### PR TITLE
Remove type hint from getSubprocessStartupinfo

### DIFF
--- a/KlipperPreprocessor.py
+++ b/KlipperPreprocessor.py
@@ -271,7 +271,7 @@ class KlipperPreprocessor(Script):
             except subprocess.TimeoutExpired:
                 self.showWarningMessage("Timeout while running klipper_estimator")
 
-    def getSubprocessStartupinfo(self) -> Optional[subprocess.STARTUPINFO]:
+    def getSubprocessStartupinfo(self):
         if sys.platform == "win32":
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW


### PR DESCRIPTION
macOS (and Linux I'm assuming?) doesn't support startupinfo - this lets the script run on those

Basic fix for #9 